### PR TITLE
test: expand coverage for autohedge

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,7 @@ libs = ["lib"]
 # Optimizer settings
 optimizer = true
 optimizer_runs = 200
+via_ir = true
 
 [rpc_endpoints]
 hyperliquid = "https://rpc.hyperliquid.xyz/evm"

--- a/src/autohedge/FullMath.sol
+++ b/src/autohedge/FullMath.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @notice 512-bit mulDiv utilities (subset of Uniswap's FullMath)
+library FullMath {
+    /// @notice Calculates floor(a×b÷denominator) with full precision.
+    /// @dev Reverts if denominator == 0 or result overflows 256 bits.
+    function mulDiv(uint256 a, uint256 b, uint256 denominator) internal pure returns (uint256 result) {
+        unchecked {
+            uint256 prod0; // Least significant 256 bits
+            uint256 prod1; // Most significant 256 bits
+            assembly {
+                let mm := mulmod(a, b, not(0))
+                prod0 := mul(a, b)
+                prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+            }
+            if (prod1 == 0) {
+                require(denominator > 0, "div/0");
+                assembly {
+                    result := div(prod0, denominator)
+                }
+                return result;
+            }
+            require(denominator > prod1, "overflow");
+
+            // Make division exact by subtracting the remainder from [prod1 prod0]
+            uint256 remainder;
+            assembly {
+                remainder := mulmod(a, b, denominator)
+                prod1 := sub(prod1, gt(remainder, prod0))
+                prod0 := sub(prod0, remainder)
+            }
+
+            // Factor powers of two out of denominator and compute largest power of two divisor of denominator.
+            uint256 twos = denominator & (~denominator + 1);
+            assembly {
+                denominator := div(denominator, twos)
+                prod0 := div(prod0, twos)
+                twos := add(div(sub(0, twos), twos), 1)
+            }
+            prod0 |= prod1 * twos;
+
+            // Invert denominator mod 2^256 and multiply by prod0
+            uint256 inv = (3 * denominator) ^ 2;
+            inv *= 2 - denominator * inv; // inverse mod 2^8
+            inv *= 2 - denominator * inv; // 2^16
+            inv *= 2 - denominator * inv; // 2^32
+            inv *= 2 - denominator * inv; // 2^64
+            inv *= 2 - denominator * inv; // 2^128
+            inv *= 2 - denominator * inv; // 2^256
+
+            result = prod0 * inv;
+            return result;
+        }
+    }
+
+    /// @notice ceil(a×b÷denominator) with full precision.
+    function mulDivRoundingUp(uint256 a, uint256 b, uint256 denominator) internal pure returns (uint256 result) {
+        result = mulDiv(a, b, denominator);
+        unchecked {
+            if (mulmod(a, b, denominator) > 0) {
+                require(result < type(uint256).max, "ru overflow");
+                result++;
+            }
+        }
+    }
+}

--- a/src/autohedge/UniV3DeltaMath.sol
+++ b/src/autohedge/UniV3DeltaMath.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./FullMath.sol";
+
+/// @notice Minimal Uniswap v3 delta helpers (token0 only)
+library UniV3DeltaMath {
+    using FullMath for uint256;
+
+    struct Range {
+        uint160 sqrtPaX96; // lower sqrt price in Q64.96
+        uint160 sqrtPbX96; // upper sqrt price in Q64.96
+        uint128 liquidity; // Uniswap v3 liquidity units
+    }
+
+    error InvalidRange();
+
+    /// @notice amount0 for liquidity across [sqrtA, sqrtB]
+    function _amount0ForLiquidity(uint160 sqrtAX96, uint160 sqrtBX96, uint128 liquidity)
+        private
+        pure
+        returns (uint256 amount0)
+    {
+        if (sqrtAX96 >= sqrtBX96) revert InvalidRange();
+        // amount0 = L * (sqrtB - sqrtA) / (sqrtB * sqrtA) * 2^96
+        // Implemented as: (liquidity << 96) * (sqrtB - sqrtA) / (sqrtB * sqrtA)
+        uint256 numerator = (uint256(liquidity) << 96) * (sqrtBX96 - sqrtAX96);
+        uint256 denominator = uint256(sqrtBX96) * uint256(sqrtAX96);
+        amount0 = FullMath.mulDivRoundingUp(numerator, 1, denominator);
+    }
+
+    /// @notice token0 inventory (delta) of a single v3 range at sqrtP.
+    /// Returns amount0 > 0 when holding token0.
+    function amount0InRange(Range memory r, uint160 sqrtPX96) internal pure returns (uint256 amount0) {
+        if (sqrtPX96 <= r.sqrtPaX96) {
+            // Fully token0
+            return _amount0ForLiquidity(r.sqrtPaX96, r.sqrtPbX96, r.liquidity);
+        } else if (sqrtPX96 >= r.sqrtPbX96) {
+            // Fully token1
+            return 0;
+        } else {
+            // Partially invested: [sqrtP, sqrtB]
+            return _amount0ForLiquidity(sqrtPX96, r.sqrtPbX96, r.liquidity);
+        }
+    }
+
+    /// @notice Sum token0 across many ranges
+    function sumAmount0(Range[] memory ranges, uint160 sqrtPX96) internal pure returns (uint256 total0) {
+        uint256 n = ranges.length;
+        for (uint256 i = 0; i < n; ++i) {
+            total0 += amount0InRange(ranges[i], sqrtPX96);
+        }
+    }
+}

--- a/src/examples/AutoHedgeManager.sol
+++ b/src/examples/AutoHedgeManager.sol
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * AutoHedgeManager
+ * ----------------
+ * Users opt-in (delegate) to hedging for a given Steer vault.
+ * Steer/keeper submits the vault's Uniswap v3 ranges (sqrt prices + liquidity).
+ * Contract computes token0 delta and rebalances a Hyperliquid perp position to target:
+ *      targetSz = - (token0_delta) * participation_fraction  (converted to perp sz decimals)
+ * Funds: simple USDC deposit -> bridge to Core -> move to perp margin (optional, but provided).
+ */
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+import {CoreWriterLib} from "@hyper-evm-lib/src/CoreWriterLib.sol";
+import {PrecompileLib} from "@hyper-evm-lib/src/PrecompileLib.sol";
+import {HLConstants} from "@hyper-evm-lib/src/common/HLConstants.sol";
+import {HLConversions} from "@hyper-evm-lib/src/common/HLConversions.sol";
+
+import {UniV3DeltaMath} from "../autohedge/UniV3DeltaMath.sol";
+
+contract AutoHedgeManager is Ownable {
+    using CoreWriterLib for *;
+
+    // --- constants / config ---
+    uint64 public constant USDC_TOKEN_ID = 0;
+
+    struct VaultConfig {
+        // Base/quote for price discovery on HyperEVM (must be registered in TokenRegistry)
+        address token0OnHL; // e.g., uETH (base)
+        address quoteOnHL; // e.g., USDC (quote), usually aligned with USDC_TOKEN_ID
+        uint32 perpIndex; // Hyperliquid perp asset id, e.g. ETH-PERP index
+        uint8 token0WeiDecimals; // decimals for token0 on HL core (for size conversion)
+        // Participation
+        uint16 participationBps; // optional override; 0 => use enabledUsers/totalUsers
+        uint32 slippageBps; // default slippage bps for IOC orders
+        bool exists;
+    }
+
+    // Ranges per vault (in storage)
+    mapping(address => UniV3DeltaMath.Range[]) internal _ranges;
+
+    // Vault metadata
+    mapping(address => VaultConfig) public vaultConfig;
+
+    // Participation (opt-in) accounting
+    mapping(address => uint256) public totalUsers; // per vault: denominator (can be LP supply buckets if you want)
+    mapping(address => uint256) public enabledUsers; // per vault: number enabled
+    mapping(address => mapping(address => bool)) public isUserEnabled; // vault => user => bool
+
+    // Last target hedge size we aimed for (perp sz units, signed)
+    mapping(address => int64) public lastTargetSz;
+
+    // Roles
+    address public rebalancer; // allowed to push new ranges + trigger rebalances
+    address public keeper; // allowed to trigger rebalances
+
+    // --- events ---
+    event VaultConfigured(
+        address indexed vault,
+        address token0,
+        address quote,
+        uint32 perpIndex,
+        uint16 participationBps,
+        uint32 slippageBps
+    );
+    event UserOptIn(address indexed vault, address indexed user);
+    event UserOptOut(address indexed vault, address indexed user);
+    event TotalsUpdated(address indexed vault, uint256 totalUsers, uint256 enabledUsers, uint16 effectiveBps);
+    event RangesUpdated(address indexed vault, uint256 nRanges, uint160 sqrtPX96, uint256 token0Delta);
+    event Rebalanced(
+        address indexed vault,
+        int64 targetSz,
+        int64 currentSz,
+        int64 deltaSz,
+        bool isBuy,
+        uint64 limitPx,
+        uint64 szPlaced,
+        uint8 tif
+    );
+
+    // --- modifiers ---
+    modifier onlyRebalancer() {
+        require(msg.sender == rebalancer || msg.sender == owner(), "not rebalancer");
+        _;
+    }
+
+    modifier onlyKeeper() {
+        require(msg.sender == keeper || msg.sender == rebalancer || msg.sender == owner(), "not keeper");
+        _;
+    }
+
+    constructor(address _owner) Ownable(_owner) {}
+
+    // -------------------------------------------------
+    // Admin / roles
+    // -------------------------------------------------
+    function setRebalancer(address who) external onlyOwner {
+        rebalancer = who;
+    }
+
+    function setKeeper(address who) external onlyOwner {
+        keeper = who;
+    }
+
+    /// @notice Configure a vault mapping to a Hyperliquid perp + spot pair
+    function configureVault(
+        address vault,
+        address token0OnHL,
+        address quoteOnHL,
+        uint32 perpIndex,
+        uint16 participationBps, // set 0 to compute from opt-ins
+        uint32 slippageBps // default IOC slippage on orders
+    ) external onlyOwner {
+        // pull decimals from HL precompile, ensures token is registered
+        PrecompileLib.TokenInfo memory t0 = PrecompileLib.tokenInfo(token0OnHL);
+
+        VaultConfig storage cfg = vaultConfig[vault];
+        cfg.token0OnHL = token0OnHL;
+        cfg.quoteOnHL = quoteOnHL;
+        cfg.perpIndex = perpIndex;
+        cfg.token0WeiDecimals = t0.weiDecimals;
+        cfg.participationBps = participationBps;
+        cfg.slippageBps = slippageBps;
+        cfg.exists = true;
+
+        emit VaultConfigured(vault, token0OnHL, quoteOnHL, perpIndex, participationBps, slippageBps);
+    }
+
+    function setParticipationBps(address vault, uint16 bps) external onlyOwner {
+        require(vaultConfig[vault].exists, "vault !exists");
+        vaultConfig[vault].participationBps = bps;
+        emit TotalsUpdated(vault, totalUsers[vault], enabledUsers[vault], effectiveParticipationBps(vault));
+    }
+
+    function setTotals(address vault, uint256 newTotalUsers) external onlyOwner {
+        require(vaultConfig[vault].exists, "vault !exists");
+        totalUsers[vault] = newTotalUsers;
+        emit TotalsUpdated(vault, newTotalUsers, enabledUsers[vault], effectiveParticipationBps(vault));
+    }
+
+    // -------------------------------------------------
+    // User delegation (opt-in / opt-out)
+    // -------------------------------------------------
+    function optIn(address vault) external {
+        require(vaultConfig[vault].exists, "vault !exists");
+        if (!isUserEnabled[vault][msg.sender]) {
+            isUserEnabled[vault][msg.sender] = true;
+            enabledUsers[vault] += 1;
+            emit UserOptIn(vault, msg.sender);
+            emit TotalsUpdated(vault, totalUsers[vault], enabledUsers[vault], effectiveParticipationBps(vault));
+        }
+    }
+
+    function optOut(address vault) external {
+        require(vaultConfig[vault].exists, "vault !exists");
+        if (isUserEnabled[vault][msg.sender]) {
+            isUserEnabled[vault][msg.sender] = false;
+            enabledUsers[vault] -= 1;
+            emit UserOptOut(vault, msg.sender);
+            emit TotalsUpdated(vault, totalUsers[vault], enabledUsers[vault], effectiveParticipationBps(vault));
+        }
+    }
+
+    function effectiveParticipationBps(address vault) public view returns (uint16 bps) {
+        VaultConfig memory cfg = vaultConfig[vault];
+        if (cfg.participationBps > 0) {
+            return cfg.participationBps;
+        }
+        // fallback: proportional to #enabled users (avoid div-by-zero)
+        uint256 tot = totalUsers[vault];
+        if (tot == 0) return 0;
+        uint256 eff = enabledUsers[vault] * 10000 / tot;
+        if (eff > 10000) eff = 10000;
+        return uint16(eff);
+    }
+
+    // -------------------------------------------------
+    // Range intake + rebalance
+    // -------------------------------------------------
+
+    /// @notice Replace all stored ranges for a vault and immediately hedge to target.
+    /// @param vault the Steer vault id (arbitrary address key)
+    /// @param newRanges array of Uniswap v3 ranges
+    /// @param sqrtPX96 current sqrt price (Q64.96) for the pool (token0 quoted in token1)
+    /// @param overrideSlippageBps set 0 to use cfg.slippageBps
+    function updateRangesAndRebalance(
+        address vault,
+        UniV3DeltaMath.Range[] calldata newRanges,
+        uint160 sqrtPX96,
+        uint32 overrideSlippageBps
+    ) external onlyRebalancer {
+        require(vaultConfig[vault].exists, "vault !exists");
+
+        // replace ranges
+        delete _ranges[vault];
+        for (uint256 i = 0; i < newRanges.length; ++i) {
+            _ranges[vault].push(newRanges[i]);
+        }
+
+        // compute LP token0 exposure
+        uint256 token0Delta = UniV3DeltaMath.sumAmount0(newRanges, sqrtPX96);
+        emit RangesUpdated(vault, newRanges.length, sqrtPX96, token0Delta);
+
+        // hedge to target
+        _rebalanceToTarget(vault, token0Delta, overrideSlippageBps);
+    }
+
+    /// @notice Re-hedge a vault using its LAST stored ranges and a fresh sqrt price.
+    function rebalanceWithPrice(address vault, uint160 sqrtPX96, uint32 overrideSlippageBps) external onlyKeeper {
+        require(vaultConfig[vault].exists, "vault !exists");
+        UniV3DeltaMath.Range[] storage ranges = _ranges[vault];
+        require(ranges.length > 0, "no ranges");
+
+        // copy to memory for math
+        UniV3DeltaMath.Range[] memory m = new UniV3DeltaMath.Range[](ranges.length);
+        for (uint256 i = 0; i < ranges.length; ++i) {
+            m[i] = ranges[i];
+        }
+
+        uint256 token0Delta = UniV3DeltaMath.sumAmount0(m, sqrtPX96);
+        emit RangesUpdated(vault, m.length, sqrtPX96, token0Delta);
+
+        _rebalanceToTarget(vault, token0Delta, overrideSlippageBps);
+    }
+
+    /// @dev core hedge logic: compute target perp size and place IOC order to move there
+    function _rebalanceToTarget(
+        address vault,
+        uint256 token0Delta, // in token0 minimal units
+        uint32 overrideSlippageBps
+    ) internal {
+        VaultConfig memory cfg = vaultConfig[vault];
+        uint16 partBps = effectiveParticipationBps(vault);
+        if (partBps == 0) {
+            // nothing to do (no participants)
+            return;
+        }
+
+        // Convert token0 units -> perp sz units
+        PrecompileLib.PerpAssetInfo memory ainfo = PrecompileLib.perpAssetInfo(cfg.perpIndex);
+        uint8 szDecimals = ainfo.szDecimals;
+
+        // scale: perpSz = token0Delta * 10^szDecimals / 10^token0WeiDecimals
+        uint256 scaled = token0Delta;
+        if (szDecimals >= cfg.token0WeiDecimals) {
+            scaled = token0Delta * (10 ** (szDecimals - cfg.token0WeiDecimals));
+        } else {
+            scaled = token0Delta / (10 ** (cfg.token0WeiDecimals - szDecimals));
+        }
+
+        // apply participation fraction: targetSz = -scaled * partBps / 1e4
+        int256 targetSzSigned = -int256(scaled * partBps / 10000);
+
+        // current perp position size (signed)
+        PrecompileLib.Position memory pos = PrecompileLib.position(address(this), uint16(cfg.perpIndex));
+        int256 currentSz = int256(pos.szi);
+
+        int256 deltaSz = targetSzSigned - currentSz;
+        if (deltaSz == 0) {
+            lastTargetSz[vault] = int64(targetSzSigned);
+            emit Rebalanced(vault, int64(targetSzSigned), int64(currentSz), 0, false, 0, 0, 0);
+            return;
+        }
+
+        bool isBuy = deltaSz > 0;
+        uint64 sz = uint64(deltaSz > 0 ? uint256(deltaSz) : uint256(-deltaSz));
+
+        // price: use perp markPx with IOC slippage bump
+        uint64 px = PrecompileLib.markPx(cfg.perpIndex);
+        uint32 slip = overrideSlippageBps > 0 ? overrideSlippageBps : cfg.slippageBps;
+        uint64 limitPx = _withSlippage(px, slip, isBuy);
+
+        // place IOC order
+        CoreWriterLib.placeLimitOrder(
+            cfg.perpIndex,
+            isBuy,
+            limitPx,
+            sz,
+            false, // reduceOnly
+            HLConstants.LIMIT_ORDER_TIF_IOC,
+            _cloid(vault, targetSzSigned, sz)
+        );
+
+        lastTargetSz[vault] = int64(targetSzSigned);
+        emit Rebalanced(
+            vault,
+            int64(targetSzSigned),
+            int64(currentSz),
+            int64(deltaSz),
+            isBuy,
+            limitPx,
+            sz,
+            HLConstants.LIMIT_ORDER_TIF_IOC
+        );
+    }
+
+    function _withSlippage(uint64 px, uint32 bps, bool up) internal pure returns (uint64) {
+        if (bps == 0) return px;
+        uint256 num = uint256(px) * (up ? (10000 + bps) : (10000 - bps));
+        return uint64(num / 10000);
+    }
+
+    function _cloid(address vault, int256 targetSz, uint64 sz) internal view returns (uint128) {
+        // cheap-ish unique client order id
+        return uint128(uint256(keccak256(abi.encodePacked(block.number, vault, targetSz, sz, address(this)))));
+    }
+
+    // -------------------------------------------------
+    // Margin ops (optional helpers)
+    // -------------------------------------------------
+
+    /// @notice Deposit EVM USDC to this contract, bridge to Core, and move to perp margin.
+    /// @dev Caller must approve this contract to spend `evmAmount` on the EVM USDC token.
+    function depositPerpMarginUSDC(address usdcEvmToken, uint256 evmAmount) external {
+        require(evmAmount > 0, "zero");
+        IERC20(usdcEvmToken).transferFrom(msg.sender, address(this), evmAmount);
+
+        // Bridge to Core
+        CoreWriterLib.bridgeToCore(usdcEvmToken, evmAmount);
+
+        // Convert to Core and then Perp units
+        uint64 tokenIndex = PrecompileLib.getTokenIndex(usdcEvmToken);
+        uint64 coreAmount = HLConversions.convertEvmToCoreAmount(tokenIndex, evmAmount);
+        uint64 perpAmount = HLConversions.convertUSDC_CoreToPerp(coreAmount);
+
+        // Move to perp account
+        CoreWriterLib.transferUsdClass(perpAmount, true);
+    }
+
+    /// @notice Move USDC from perp back to EVM (best-effort; assumes sufficient withdrawable).
+    /// @param coreAmount amount in Core USDC units to withdraw to EVM.
+    /// @dev For non-HYPE tokens, ensure the contract holds some HYPE on core for transfer gas.
+    function withdrawUSDCToEvm(uint64 coreAmount, address usdcEvmToken) external onlyOwner {
+        // Move from perp to spot (Core)
+        uint64 perpAmount = HLConversions.convertUSDC_CoreToPerp(coreAmount);
+        CoreWriterLib.transferUsdClass(perpAmount, false);
+
+        // Bridge to EVM using EVM amount (convert Core->EVM)
+        uint64 tokenIndex = PrecompileLib.getTokenIndex(usdcEvmToken);
+        uint256 evmAmount = HLConversions.convertCoreToEvmAmount(tokenIndex, coreAmount);
+        CoreWriterLib.bridgeToEvm(usdcEvmToken, evmAmount);
+    }
+
+    // -------------------------------------------------
+    // Views
+    // -------------------------------------------------
+    function getRanges(address vault) external view returns (UniV3DeltaMath.Range[] memory out) {
+        UniV3DeltaMath.Range[] storage s = _ranges[vault];
+        out = new UniV3DeltaMath.Range[](s.length);
+        for (uint256 i = 0; i < s.length; ++i) {
+            out[i] = s[i];
+        }
+    }
+}

--- a/test/AutoHedgeManager.t.sol
+++ b/test/AutoHedgeManager.t.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import {AutoHedgeManager} from "../src/examples/AutoHedgeManager.sol";
+import {UniV3DeltaMath} from "../src/autohedge/UniV3DeltaMath.sol";
+import {PrecompileLib} from "../src/PrecompileLib.sol";
+import {HLConstants} from "../src/common/HLConstants.sol";
+import {ITokenRegistry} from "../src/interfaces/ITokenRegistry.sol";
+
+contract AutoHedgeManagerTest is Test {
+    AutoHedgeManager manager;
+    address constant vault = address(0xdead);
+    address constant token0 = address(0x123);
+    address constant quote = address(0x456);
+    uint32 constant perpIndex = 1;
+
+    uint256 constant Q96 = 2**96;
+
+    function setUp() public {
+        manager = new AutoHedgeManager(address(this));
+        manager.setRebalancer(address(this));
+
+        // Mock token registry lookup
+        address registry = 0x0b51d1A9098cf8a72C325003F44C194D41d7A85B;
+        vm.mockCall(
+            registry,
+            abi.encodeWithSelector(ITokenRegistry.getTokenIndex.selector, token0),
+            abi.encode(uint32(1))
+        );
+
+        // Mock token info precompile
+        PrecompileLib.TokenInfo memory ti;
+        ti.name = "uTKN";
+        ti.spots = new uint64[](1);
+        ti.spots[0] = 0;
+        ti.deployerTradingFeeShare = 0;
+        ti.deployer = address(0);
+        ti.evmContract = token0;
+        ti.szDecimals = 6;
+        ti.weiDecimals = 6;
+        ti.evmExtraWeiDecimals = 0;
+        vm.mockCall(
+            HLConstants.TOKEN_INFO_PRECOMPILE_ADDRESS,
+            abi.encode(uint64(1)),
+            abi.encode(ti)
+        );
+
+        // Mock perp asset info
+        PrecompileLib.PerpAssetInfo memory pinfo;
+        pinfo.coin = "TKN";
+        pinfo.marginTableId = 0;
+        pinfo.szDecimals = 6;
+        pinfo.maxLeverage = 50;
+        pinfo.onlyIsolated = false;
+        vm.mockCall(
+            HLConstants.PERP_ASSET_INFO_PRECOMPILE_ADDRESS,
+            abi.encode(perpIndex),
+            abi.encode(pinfo)
+        );
+
+        // Mock position precompile
+        PrecompileLib.Position memory pos;
+        pos.szi = 0;
+        pos.entryNtl = 0;
+        pos.isolatedRawUsd = 0;
+        pos.leverage = 0;
+        pos.isIsolated = false;
+        vm.mockCall(
+            HLConstants.POSITION_PRECOMPILE_ADDRESS,
+            abi.encode(address(manager), perpIndex),
+            abi.encode(pos)
+        );
+
+        // Mock mark price
+        vm.mockCall(
+            HLConstants.MARK_PX_PRECOMPILE_ADDRESS,
+            abi.encode(perpIndex),
+            abi.encode(uint64(2000))
+        );
+
+        // Mock CoreWriter sendRawAction
+        vm.mockCall(
+            address(0x3333333333333333333333333333333333333333),
+            bytes("") ,
+            abi.encode()
+        );
+
+        manager.configureVault(vault, token0, quote, perpIndex, 10000, 50);
+    }
+
+    function test_updateRangesAndRebalance_setsTarget() public {
+        UniV3DeltaMath.Range[] memory ranges = new UniV3DeltaMath.Range[](1);
+        ranges[0] = UniV3DeltaMath.Range({
+            sqrtPaX96: uint160(Q96),
+            sqrtPbX96: uint160(Q96 * 2),
+            liquidity: 1e6
+        });
+        uint160 sqrtP = uint160(Q96 * 3 / 2);
+
+        vm.expectCall(address(0x3333333333333333333333333333333333333333), bytes(""));
+
+        manager.updateRangesAndRebalance(vault, ranges, sqrtP, 0);
+
+        assertEq(manager.lastTargetSz(vault), -166667);
+    }
+
+    function test_optInAndOut() public {
+        assertEq(manager.enabledUsers(vault), 0);
+
+        manager.optIn(vault);
+        assertEq(manager.enabledUsers(vault), 1);
+        assertTrue(manager.isUserEnabled(vault, address(this)));
+
+        manager.optOut(vault);
+        assertEq(manager.enabledUsers(vault), 0);
+        assertFalse(manager.isUserEnabled(vault, address(this)));
+    }
+
+    function test_rebalanceWithParticipationFraction() public {
+        manager.setParticipationBps(vault, 0);
+        manager.setTotals(vault, 10);
+        for (uint256 i = 0; i < 5; i++) {
+            address user = address(uint160(i + 1));
+            vm.prank(user);
+            manager.optIn(vault);
+        }
+
+        UniV3DeltaMath.Range[] memory ranges = new UniV3DeltaMath.Range[](1);
+        ranges[0] = UniV3DeltaMath.Range({
+            sqrtPaX96: uint160(Q96),
+            sqrtPbX96: uint160(Q96 * 2),
+            liquidity: 1e6
+        });
+        uint160 sqrtP = uint160(Q96 * 3 / 2);
+
+        vm.expectCall(address(0x3333333333333333333333333333333333333333), bytes(""));
+        manager.updateRangesAndRebalance(vault, ranges, sqrtP, 0);
+
+        assertEq(manager.lastTargetSz(vault), -83333);
+    }
+
+    function test_rebalanceWithPrice_updatesTarget() public {
+        UniV3DeltaMath.Range[] memory ranges = new UniV3DeltaMath.Range[](1);
+        ranges[0] = UniV3DeltaMath.Range({
+            sqrtPaX96: uint160(Q96),
+            sqrtPbX96: uint160(Q96 * 2),
+            liquidity: 1e6
+        });
+        uint160 sqrtP = uint160(Q96 * 3 / 2);
+
+        vm.expectCall(address(0x3333333333333333333333333333333333333333), bytes(""));
+        manager.updateRangesAndRebalance(vault, ranges, sqrtP, 0);
+
+        // pretend hedge was executed
+        PrecompileLib.Position memory pos;
+        pos.szi = -166667;
+        vm.mockCall(
+            HLConstants.POSITION_PRECOMPILE_ADDRESS,
+            abi.encode(address(manager), perpIndex),
+            abi.encode(pos)
+        );
+
+        uint160 newSqrtP = uint160(Q96 * 3);
+        vm.expectCall(address(0x3333333333333333333333333333333333333333), bytes(""));
+        manager.rebalanceWithPrice(vault, newSqrtP, 0);
+
+        assertEq(manager.lastTargetSz(vault), 0);
+    }
+
+    function test_noRebalanceWhenNoParticipants() public {
+        manager.setParticipationBps(vault, 0);
+
+        UniV3DeltaMath.Range[] memory ranges = new UniV3DeltaMath.Range[](1);
+        ranges[0] = UniV3DeltaMath.Range({
+            sqrtPaX96: uint160(Q96),
+            sqrtPbX96: uint160(Q96 * 2),
+            liquidity: 1e6
+        });
+        uint160 sqrtP = uint160(Q96 * 3 / 2);
+
+        vm.expectCall(address(0x3333333333333333333333333333333333333333), bytes(""), 0);
+        manager.updateRangesAndRebalance(vault, ranges, sqrtP, 0);
+
+        assertEq(manager.lastTargetSz(vault), 0);
+    }
+}

--- a/test/FullMath.t.sol
+++ b/test/FullMath.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import {FullMath} from "../src/autohedge/FullMath.sol";
+
+contract FullMathTest is Test {
+    function test_mulDiv() public {
+        uint256 result = FullMath.mulDiv(4, 5, 2);
+        assertEq(result, 10);
+    }
+
+    function test_mulDivRoundingUp() public {
+        uint256 result = FullMath.mulDivRoundingUp(5, 5, 2);
+        assertEq(result, 13);
+    }
+
+    function test_mulDiv_largeNumbers() public {
+        uint256 a = 1 << 200;
+        uint256 b = 1 << 200;
+        uint256 d = 1 << 150;
+        uint256 result = FullMath.mulDiv(a, b, d);
+        assertEq(result, 1 << 250);
+    }
+}

--- a/test/UniV3DeltaMath.t.sol
+++ b/test/UniV3DeltaMath.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import {UniV3DeltaMath} from "../src/autohedge/UniV3DeltaMath.sol";
+
+contract UniV3DeltaMathTest is Test {
+    uint256 constant Q96 = 2**96;
+
+    function callAmount0(UniV3DeltaMath.Range memory r, uint160 sqrtP) external pure returns (uint256) {
+        return UniV3DeltaMath.amount0InRange(r, sqrtP);
+    }
+
+    function test_amount0InRange_partial() public {
+        UniV3DeltaMath.Range memory r = UniV3DeltaMath.Range({
+            sqrtPaX96: uint160(Q96),
+            sqrtPbX96: uint160(Q96 * 2),
+            liquidity: 1e6
+        });
+        uint160 sqrtP = uint160(Q96 * 3 / 2);
+        uint256 amt = UniV3DeltaMath.amount0InRange(r, sqrtP);
+        assertEq(amt, 166667);
+    }
+
+    function test_amount0InRange_fullyToken0() public {
+        UniV3DeltaMath.Range memory r = UniV3DeltaMath.Range({
+            sqrtPaX96: uint160(Q96),
+            sqrtPbX96: uint160(Q96 * 2),
+            liquidity: 1e6
+        });
+        uint160 sqrtP = uint160(Q96 / 2);
+        uint256 amt = UniV3DeltaMath.amount0InRange(r, sqrtP);
+        assertEq(amt, 500000);
+    }
+
+    function test_amount0InRange_fullyToken1() public {
+        UniV3DeltaMath.Range memory r = UniV3DeltaMath.Range({
+            sqrtPaX96: uint160(Q96),
+            sqrtPbX96: uint160(Q96 * 2),
+            liquidity: 1e6
+        });
+        uint160 sqrtP = uint160(Q96 * 3);
+        uint256 amt = UniV3DeltaMath.amount0InRange(r, sqrtP);
+        assertEq(amt, 0);
+    }
+
+    function test_amount0InRange_invalidRangeReverts() public {
+        UniV3DeltaMath.Range memory r = UniV3DeltaMath.Range({
+            sqrtPaX96: uint160(Q96 * 2),
+            sqrtPbX96: uint160(Q96),
+            liquidity: 1e6
+        });
+        uint160 sqrtP = uint160(Q96 / 2);
+        vm.expectRevert(UniV3DeltaMath.InvalidRange.selector);
+        this.callAmount0(r, sqrtP);
+    }
+
+    function test_sumAmount0_twoRanges() public {
+        UniV3DeltaMath.Range[] memory ranges = new UniV3DeltaMath.Range[](2);
+        ranges[0] = UniV3DeltaMath.Range({sqrtPaX96: uint160(Q96), sqrtPbX96: uint160(Q96 * 2), liquidity: 1e6});
+        ranges[1] = UniV3DeltaMath.Range({sqrtPaX96: uint160(Q96), sqrtPbX96: uint160(Q96 * 2), liquidity: 2e6});
+
+        uint160 sqrtP = uint160(Q96 * 3 / 2);
+        uint256 total = UniV3DeltaMath.sumAmount0(ranges, sqrtP);
+        assertEq(total, 500001);
+    }
+}


### PR DESCRIPTION
## Summary
- broaden FullMath unit tests to cover large-number mulDiv
- add UniV3DeltaMath cases for edge range scenarios
- exercise AutoHedgeManager participation fractions, price updates, and empty participant paths

## Testing
- `forge test --via-ir`

------
https://chatgpt.com/codex/tasks/task_e_6897bf176530832fb6ff78e1f01ceeef